### PR TITLE
BLD : add patch to epics-base make file to find correct headers

### DIFF
--- a/epics-base/build.sh
+++ b/epics-base/build.sh
@@ -1,18 +1,2 @@
 #!/bin/bash
 make -j$(getconf _NPROCESSORS_ONLN)
-EPICS_BASE=$PREFIX/lib/epics
-
-install -d $PREFIX/lib
-cp -Prv lib/linux-x86_64/* $PREFIX/lib
-
-install -d $PREFIX/bin
-cp -Prv bin/linux-x86_64/caget $PREFIX/bin
-cp -Prv bin/linux-x86_64/caput $PREFIX/bin
-cp -Prv bin/linux-x86_64/camonitor $PREFIX/bin
-cp -Prv bin/linux-x86_64/caRepeater $PREFIX/bin
-cp -Prv bin/linux-x86_64/softIoc $PREFIX/bin
-
-for X in bin configure db dbd include lib startup templates; do
-  install -d $EPICS_BASE/$X
-  cp -Prv $X/* $EPICS_BASE/$X
-done

--- a/epics-base/config.patch
+++ b/epics-base/config.patch
@@ -1,0 +1,21 @@
+diff -uwr base-3.14.12.4/configure/CONFIG_COMMON base-3.14.12.4_wrk/configure/CONFIG_COMMON
+--- configure/CONFIG_COMMON	2013-12-16 16:56:27.000000000 -0500
++++ configure/CONFIG_COMMON	2014-12-31 13:58:41.690924788 -0500
+@@ -59,7 +59,7 @@
+ #-------------------------------------------------------
+ # Directories
+
+-INSTALL_LOCATION            = $(TOP)
++INSTALL_LOCATION            = $(PREFIX)
+
+ INSTALL_LOCATION_LIB        = $(INSTALL_LOCATION)/lib
+ INSTALL_LOCATION_BIN        = $(INSTALL_LOCATION)/bin
+@@ -200,7 +200,7 @@
+ OP_SYS_INCLUDES =
+
+ # Makefile specific flags
+-USR_INCLUDES =
++USR_INCLUDES = $(PREFIX)/include
+ USR_CFLAGS =
+ USR_CXXFLAGS =
+ USR_LDFLAGS =

--- a/epics-base/meta.yaml
+++ b/epics-base/meta.yaml
@@ -7,6 +7,9 @@ source:
     fn: baseR3.14.12.4.tar.gz
     url: http://www.aps.anl.gov/epics/download/base/baseR3.14.12.4.tar.gz
 
+    patches:
+      - config.patch
+
 build:
   number: 0
 


### PR DESCRIPTION
This might be able to simplify the build script as well (as it should correctly install to $PREFIX now), but I am not getting past the linking step using the stock readline.