### PR TITLE
BUG: widechar support for ncurses not built (ncursesw)

### DIFF
--- a/ncurses/build.sh
+++ b/ncurses/build.sh
@@ -3,7 +3,7 @@
 ./configure --prefix=$PREFIX \
     --without-debug --without-ada --without-manpages \
     --with-shared --disable-overwrite --with-termlib=tinfo \
-    --with-normal 
+    --with-normal --enable-widec
 
 make -j$(getconf _NPROCESSORS_ONLN)
 make install


### PR DESCRIPTION
When this package is installed, readline, curses, and IPython itself don't work unless configure flag `--enable-widec` is set.

```python
(env_test) $ ipython
WARNING: Readline services not available or not loaded.
WARNING: The auto-indent feature requires the readline library
Python 2.7.9 |Continuum Analytics, Inc.| (default, Dec 15 2014, 10:34:00)
Type "copyright", "credits" or "license" for more information.

IPython 2.3.1 -- An enhanced Interactive Python.
Anaconda is brought to you by Continuum Analytics.
Please check out: http://continuum.io/thanks and https://binstar.org
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import readline
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-c3914f5d8425> in <module>()
----> 1 import readline

ImportError: /lib/i386-linux-gnu/libncursesw.so.5: undefined symbol: _nc_putchar
```