### PR TITLE
BLD : add patch to make sure sip version gets set

### DIFF
--- a/master/vistrails-upstream/meta.yaml
+++ b/master/vistrails-upstream/meta.yaml
@@ -11,6 +11,9 @@ build:
   number: 0
   string: {{ environ.get('GIT_BUILD_STR', '') }}_np{{ np }}py{{ py }}
 
+  patches:
+    - qt_sip.patch
+
 build:
   # preserve_egg_dir: True
   entry_points:

--- a/master/vistrails-upstream/qt_sip.patch
+++ b/master/vistrails-upstream/qt_sip.patch
@@ -1,0 +1,21 @@
+diff --git a/vistrails/run.py b/vistrails/run.py
+index a5034de..aa87590 100644
+--- vistrails/run.py
++++ vistrails/run.py
+@@ -34,6 +34,16 @@
+ ##
+ ###############################################################################
+ """Main file for the VisTrails distribution."""
++# imports to make sure the new versions of all the QT apis are used
++# this is needed to
++import sip
++sip.setapi('QDate', 2)
++sip.setapi('QDateTime', 2)
++sip.setapi('QString', 2)
++sip.setapi('QTextStream', 2)
++sip.setapi('QTime', 2)
++sip.setapi('QUrl', 2)
++sip.setapi('QVariant', 2)
+
+ import os
+ import sys


### PR DESCRIPTION
enaml uses v2 of all the pyqt apis but these api levels
must be set before any part of pyqt is imported.  If VT loads
before enaml (which it does if you are trying to use
enaml in VT) then pyqt gets imported with some of the api levels
as v1.

Added a patch to the build to make the first thing done in `run.py`
to be setting all the sip api levels to v2

Closes https://github.com/Nikea/Internal/issues/9