### PR TITLE
ENH : add conda-env requirement on conda_etc

### DIFF
--- a/releases/conda_etc/meta.yaml
+++ b/releases/conda_etc/meta.yaml
@@ -3,7 +3,10 @@ package:
   version: '1'
 
 build:
-  number: 0
+  number: 5
 
+requirements:
+  run:
+    - conda-env >= 2.4
 about:
   summary: 'Make user the $PREFIX/etc path is available in CONDA_ETC_'


### PR DESCRIPTION
This is to ensure that a new-enough version of conda
(which knows to source the files in etc) is installed.