### PR TITLE
MNT: Loosen most versions; add ipython stuff.

### DIFF
--- a/beamline-environments/analysis/meta.yaml
+++ b/beamline-environments/analysis/meta.yaml
@@ -3,16 +3,17 @@ package:
   version: '0.1'
 
 build:
-  number: 0
+  number: 5
 
 requirements:
   run:
-    - python ==3.4
+    - python ==3.4.3
+    - ipython-notebook
+    - ipywidgets
     - dataportal >=0.2.2
-    - channelarchiver >=v0.0.5.post6
-    - lmfit >=0.9.0rc1.post0
-    - matplotlib >=1.5.0rc1
-    - album >=v0.0.1
-    - scikit-xray >=v0.0.5
-    - xray-vision >=v0.0.3
-    - pims >=v0.3.0rc1
+    - channelarchiver
+    - lmfit
+    - matplotlib
+    - album
+    - scikit-xray
+    - xray-vision

--- a/recipes/bluesky/v0.2.1/build.sh
+++ b/recipes/bluesky/v0.2.1/build.sh
@@ -1,0 +1,3 @@
+
+$PYTHON setup.py build
+$PYTHON setup.py install --single-version-externally-managed --record=/dev/null

--- a/recipes/bluesky/v0.2.1/meta.yaml
+++ b/recipes/bluesky/v0.2.1/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: bluesky
+  version: v0.2.1
+
+source:
+  git_url: https://github.com/NSLS-II/bluesky
+  git_rev: v0.2.1
+
+build:
+  # Note that this will override the default build string with the Python
+  # and NumPy versions
+  number: 0
+
+requirements:
+  build:
+    - python ==3.4
+
+  run:
+    - python >=3.4
+    - jsonschema
+    - super_state_machine
+    - numpy
+    - metadatastore
+    - filestore
+    - matplotlib
+    - prettytable
+    - cycler
+    - traitlets
+    - history
+    - lmfit
+
+test:
+  requires:
+    - nslsii_dev_configuration
+  imports:
+    - 'bluesky'
+    - 'bluesky.examples'
+
+about:
+  home: https://github.com/NSLS-II/bluesky
+  license: BSD

--- a/recipes/dataportal/v0.2.2/meta.yaml
+++ b/recipes/dataportal/v0.2.2/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: v0.2.2
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -26,7 +26,6 @@ requirements:
     - six
     - humanize
     - tzlocal
-    - scipy ==0.15.1
 
 test:
   requires:

--- a/recipes/scikit-xray/v0.0.5/meta.yaml
+++ b/recipes/scikit-xray/v0.0.5/meta.yaml
@@ -7,7 +7,7 @@ source:
   git_rev: v0.0.5
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - numpy
-    - scipy ==0.15.1
+    - scipy
     - six
     - xraylib
     - scikit-image


### PR DESCRIPTION
1. `==3.4` locks to 3.4.0, not allowing 3.4.3. See http://conda.pydata.org/docs/spec.html
2. One or more of the very-carefully-specified versions produced a conflict, but conda could not provide a specific hint as to what. We have working versions of everything on latest, so I loosened these. Feel free to lock them down in a future PR if you want to, but I don't think it's worth anyone's time.
3. We need ipython-notebook for jupyterhub, and ipywidgets is not included in that metapackage, so I added that too.