### PR TITLE
ENH: more recipes

### DIFF
--- a/recipes/carchivetools/dev/build.sh
+++ b/recipes/carchivetools/dev/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export CPPFLAGS='-I $PREFIX/include'
+${PYTHON} setup.py build
+${PYTHON} setup.py install

--- a/recipes/carchivetools/dev/meta.yaml
+++ b/recipes/carchivetools/dev/meta.yaml
@@ -1,0 +1,32 @@
+package:
+    name: carchivetools
+    version: 2.2.post{{ environ['GIT_DESCRIBE_NUMBER'] }}
+
+source:
+    git_url: https://github.com/tacaswell/carchivetools
+    git_rev: fix_py3k
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - numpy
+        - protobuf
+        - service_identity
+    run:
+        - python
+        - numpy
+        - twisted
+        - protobuf
+        - service_identity
+
+test:
+    imports:
+        - carchive
+
+about:
+    home: https://github.com/epicsdeb/carchivetools
+    summary: Channel Archiver shell tools and library

--- a/recipes/protobuf/dev/build.sh
+++ b/recipes/protobuf/dev/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+./autogen.sh
+./configure --prefix=$PREFIX
+make -j 8
+make check -j 8
+make install -j 8
+
+export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
+
+cd python
+python setup.py -q build_py
+python setup.py -q build
+python setup.py -q test -q
+
+python setup.py install

--- a/recipes/protobuf/dev/meta.yaml
+++ b/recipes/protobuf/dev/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: protobuf
+  version: {{ '{}.{}.post{}+'.format(*(environ.get('GIT_DESCRIBE_TAG', 'v3-a-1-5-g'))[1:].split('-')) }}{{ environ['GIT_DESCRIBE_NUMBER'] }}
+
+source:
+  git_url: git@github.com:google/protobuf.git
+  md5: master
+
+build:
+    number: 0
+    string: {{ environ.get('GIT_BUILD_STR', '') }}_py{{ py }}
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+
+  run:
+    - python
+    - setuptools
+    - six
+
+about:
+  home: http://code.google.com/p/protobuf/
+  license: New BSD License
+  summary: 'Protocol Buffers'

--- a/recipes/twisted/15.4.0/build.sh
+++ b/recipes/twisted/15.4.0/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/twisted/15.4.0/meta.yaml
+++ b/recipes/twisted/15.4.0/meta.yaml
@@ -1,0 +1,62 @@
+package:
+  name: twisted
+  version: "15.4.0"
+
+source:
+  fn: Twisted-15.4.0.tar.bz2
+  url: https://pypi.python.org/packages/source/T/Twisted/Twisted-15.4.0.tar.bz2
+  md5: 5337ffb6aeeff3790981a2cd56db9655
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - twisted = twisted:main
+    #
+    # Would create an entry point called twisted that calls twisted.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - zope.interface >=4.0.2
+
+  run:
+    - python
+    - zope.interface >=4.0.2
+
+# test:
+  # Python imports
+  # imports:
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: http://twistedmatrix.com/
+  license: MIT
+  summary: 'An asynchronous networking framework written in Python'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/twisted/bld.bat
+++ b/recipes/twisted/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.


### PR DESCRIPTION
We might be able do drop back to a stable version of protobuf, but the
python3 support is newish and rapidly improving.

Need to use one of my branches for carchivetools to get python3 support.

related to https://github.com/NSLS-II/wishlist/issues/85